### PR TITLE
bugfix: fix the TabError of pqi.py

### DIFF
--- a/PQI/pqi.py
+++ b/PQI/pqi.py
@@ -136,5 +136,4 @@ def main():
 
 if __name__ == '__main__':
     print(APP_DESC)
-	main()
-
+    main()


### PR DESCRIPTION
Replace the `Tab` in `PQI/pqi.py` with spaces.