### PR TITLE
Update douban PyPI url

### DIFF
--- a/PQI/pqi.py
+++ b/PQI/pqi.py
@@ -48,7 +48,7 @@ if not os.path.exists(SOURCES_NAME):
         pickle.dump({
             "pypi": "https://pypi.python.org/simple/",
             "tuna": "https://pypi.tuna.tsinghua.edu.cn/simple",
-            "douban": "http://pypi.douban.com/simple/",
+            "douban": "https://pypi.doubanio.com/simple/",
             "aliyun": "https://mirrors.aliyun.com/pypi/simple/",
             "ustc": "https://mirrors.ustc.edu.cn/pypi/web/simple"
         }, fp)


### PR DESCRIPTION
The douban PyPI can use the new url *https://pypi.doubanio.com/simple/*

You can force to update the url with the following command: 

```
pqi use douban
```